### PR TITLE
Explicitly demonstrate correct handling of newline quoting and escaping

### DIFF
--- a/unquote_test.go
+++ b/unquote_test.go
@@ -36,7 +36,9 @@ var simpleSplitTest = []struct {
 	{"don\\'t you know the dewey decimal system\\?", []string{"don't", "you", "know", "the", "dewey", "decimal", "system?"}},
 	{"'don'\\''t you know the dewey decimal system?'", []string{"don't you know the dewey decimal system?"}},
 	{"one '' two", []string{"one", "", "two"}},
-	{"text with\\\na newline", []string{"text", "witha", "newline"}},
+	{"text with\\\na backslash-escaped newline", []string{"text", "witha", "backslash-escaped", "newline"}},
+	{"text \"with\\\na\" quoted, backslash-escaped newline", []string{"text", "witha", "quoted,", "backslash-escaped", "newline"}},
+	{"text \"with\na\" quoted, unescaped newline", []string{"text", "with\na", "quoted,", "unescaped" "newline"}},
 	{"\"quoted\\d\\\\\\\" text with a\\\nnewline\"", []string{"quoted\\d\\\" text with anewline"}},
 	{"foo\"bar\"baz", []string{"foobarbaz"}},
 }


### PR DESCRIPTION
Obviously a noop in terms of actual behavior; that said, hopefully this might reduce the number of objections from folks who don't inspect precisely what the test suite is asserting closely enough. :)
