### PR TITLE
Fix prefix-repeat bug in Join when arguments include special characters and no whitespace

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -50,7 +50,7 @@ func quote(word string, buf *bytes.Buffer) {
 		if strings.ContainsRune(specialChars, c) || (atStart && strings.ContainsRune(prefixChars, c)) {
 			// copy the non-special chars up to this point
 			if len(cur) < len(prev) {
-				buf.WriteString(word[0 : len(prev)-len(cur)-l])
+				buf.WriteString(prev[0 : len(prev)-len(cur)-l])
 			}
 			buf.WriteByte('\\')
 			buf.WriteRune(c)

--- a/quote_test.go
+++ b/quote_test.go
@@ -25,4 +25,6 @@ var simpleJoinTest = []struct {
 	{[]string{"~user", "u~ser", " ~user", "!~user"}, "\\~user u~ser ' ~user' \\!~user"},
 	{[]string{"foo*", "M{ovies,usic}", "ab[cd]", "%3"}, "foo\\* M\\{ovies,usic} ab\\[cd] %3"},
 	{[]string{"one", "", "three"}, "one '' three"},
+	{[]string{"some(parentheses)"}, "some\\(parentheses\\)"},
+	{[]string{"$some_ot~her_)spe!cial_*_characters"}, "\\$some_ot~her_\\)spe\\!cial_\\*_characters"},
 }


### PR DESCRIPTION
I encountered a bug with the Join method that is triggered by meeting two conditions in an argument ("word" in the quote method) that are just narrowly missed in the existing test suite:
- no whitespace (if there is whitespace, the quoted-string method is used instead)
- two or more special characters

When these conditions are met, then you get results like this:
```
> shellquote.Join("some(parentheses)")
"some\\(some(parent\\)"
> shellquote.Join("$some_ot~her_)spe!cial_*_characters")
"\\$$some_ot~her\\)$so\\!$some\\*_characters"
```

In each case, you can see that the beginning ("some(pa..." and "$some...", respectively) is repeated before each of the special characters.

This patch includes two test cases that exercise this bug as well as a simple fix. `word[0:...]` will always return a segment starting at the beginning of the current argument, as `word` is unmodified throughout `quote`, while `prev` is used to denote the segment to write either when the end of the string or a special character is encountered.