### PR TITLE
Fix a bug that causes infinite loop.

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -84,8 +84,8 @@ quote:
 				inQuote = true
 			}
 			buf.WriteString(word[0:i])
-			word = word[i+1:]
 		}
+		word = word[i+1:]
 		if inQuote {
 			buf.WriteByte('\'')
 			inQuote = false

--- a/quote_test.go
+++ b/quote_test.go
@@ -27,4 +27,5 @@ var simpleJoinTest = []struct {
 	{[]string{"one", "", "three"}, "one '' three"},
 	{[]string{"some(parentheses)"}, "some\\(parentheses\\)"},
 	{[]string{"$some_ot~her_)spe!cial_*_characters"}, "\\$some_ot~her_\\)spe\\!cial_\\*_characters"},
+	{[]string{"' "}, "\\'' '"},
 }


### PR DESCRIPTION
When the single quote is a first character in the argument (that also
contains white spaces), the Join method goes into infinite loop because
word variable is not being updated.

Added a unit test that is failing (never ends) without the fix.