### PR TITLE
Handle line continuations in whitespace

### DIFF
--- a/unquote.go
+++ b/unquote.go
@@ -40,6 +40,18 @@ func Split(input string) (words []string, err error) {
 		if strings.ContainsRune(splitChars, c) {
 			input = input[l:]
 			continue
+		} else if c == escapeChar {
+			// Look ahead for escaped newline so we can skip over it
+			next := input[l:]
+			if len(next) == 0 {
+				err = UnterminatedEscapeError
+				return
+			}
+			c2, l2 := utf8.DecodeRuneInString(next)
+			if c2 == '\n' {
+				input = next[l2:]
+				continue
+			}
 		}
 
 		var word string

--- a/unquote_test.go
+++ b/unquote_test.go
@@ -51,4 +51,5 @@ var errorSplitTest = []struct {
 	{"'test'\\''ing", UnterminatedSingleQuoteError},
 	{"\"foo'bar", UnterminatedDoubleQuoteError},
 	{"foo\\", UnterminatedEscapeError},
+	{"   \\", UnterminatedEscapeError},
 }

--- a/unquote_test.go
+++ b/unquote_test.go
@@ -39,6 +39,7 @@ var simpleSplitTest = []struct {
 	{"text with\\\na backslash-escaped newline", []string{"text", "witha", "backslash-escaped", "newline"}},
 	{"text \"with\na\" quoted newline", []string{"text", "with\na", "quoted", "newline"}},
 	{"\"quoted\\d\\\\\\\" text with\\\na backslash-escaped newline\"", []string{"quoted\\d\\\" text witha backslash-escaped newline"}},
+	{"text with an escaped \\\n newline in the middle", []string{"text", "with", "an", "escaped", "newline", "in", "the", "middle"}},
 	{"foo\"bar\"baz", []string{"foobarbaz"}},
 }
 


### PR DESCRIPTION
While I was working on [a PR for cespare/reflex](https://github.com/cespare/reflex/pull/48), I discovered that go-shellquote's `Split()` function erroneously treats line continuations that occur before the first word, or in the middle of whitespace between subsequent words, as being an extra word that's an empty string.  In that PR, I worked around the issue by stripping such continuation characters from the input, but go-shellquote should be able to handle them without that workaround.

This PR corrects that issue by changing the whitespace-skipping loop to skip line continuations in the same way they're skipped everywhere else.