### PR TITLE
Add go.mod, fix quoting of tilde (#1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kgadams/go-shellquote
+
+go 1.19

--- a/quote.go
+++ b/quote.go
@@ -21,9 +21,8 @@ func Join(args ...string) string {
 }
 
 const (
-	specialChars      = "\\'\"`${[|&;<>()*?!"
+	specialChars      = "\\'\"`${[|&;<>()*?!~"
 	extraSpecialChars = " \t\n"
-	prefixChars       = "~"
 )
 
 func quote(word string, buf *bytes.Buffer) {
@@ -43,11 +42,10 @@ func quote(word string, buf *bytes.Buffer) {
 	}
 
 	cur, prev := word, word
-	atStart := true
 	for len(cur) > 0 {
 		c, l := utf8.DecodeRuneInString(cur)
 		cur = cur[l:]
-		if strings.ContainsRune(specialChars, c) || (atStart && strings.ContainsRune(prefixChars, c)) {
+		if strings.ContainsRune(specialChars, c) {
 			// copy the non-special chars up to this point
 			if len(cur) < len(prev) {
 				buf.WriteString(prev[0 : len(prev)-len(cur)-l])
@@ -60,7 +58,6 @@ func quote(word string, buf *bytes.Buffer) {
 			buf.Truncate(origLen)
 			goto quote
 		}
-		atStart = false
 	}
 	if len(prev) > 0 {
 		buf.WriteString(prev)

--- a/quote_test.go
+++ b/quote_test.go
@@ -22,10 +22,10 @@ var simpleJoinTest = []struct {
 	{[]string{"hello", "goodbye"}, "hello goodbye"},
 	{[]string{"don't you know the dewey decimal system?"}, "'don'\\''t you know the dewey decimal system?'"},
 	{[]string{"don't", "you", "know", "the", "dewey", "decimal", "system?"}, "don\\'t you know the dewey decimal system\\?"},
-	{[]string{"~user", "u~ser", " ~user", "!~user"}, "\\~user u~ser ' ~user' \\!~user"},
+	{[]string{"~user", "u~ser", " ~user", "!~user"}, "\\~user u\\~ser ' ~user' \\!\\~user"},
 	{[]string{"foo*", "M{ovies,usic}", "ab[cd]", "%3"}, "foo\\* M\\{ovies,usic} ab\\[cd] %3"},
 	{[]string{"one", "", "three"}, "one '' three"},
 	{[]string{"some(parentheses)"}, "some\\(parentheses\\)"},
-	{[]string{"$some_ot~her_)spe!cial_*_characters"}, "\\$some_ot~her_\\)spe\\!cial_\\*_characters"},
+	{[]string{"$some_ot~her_)spe!cial_*_characters"}, "\\$some_ot\\~her_\\)spe\\!cial_\\*_characters"},
 	{[]string{"' "}, "\\'' '"},
 }


### PR DESCRIPTION
Tilde needs to be escaped anywhere in the string if an = sign is part of the string. So we can just as well escape it anywhere.